### PR TITLE
Initial files for puya

### DIFF
--- a/flash/puya/P25Q16H.toml
+++ b/flash/puya/P25Q16H.toml
@@ -1,5 +1,6 @@
 # Settings for the Puya P25Q16H 2MiB SPI flash.
 # Datasheet: https://datasheet.lcsc.com/lcsc/2006121819_-PUYA--P25Q16H-UXH-IR_C559220.pdf
+# This config is still untested.
 total_size = 0x200000 # 2 MiB # Page 17
 capacity = 0x15 
 manufacturer_id = 0x85 #  Page 49

--- a/flash/puya/P25Q16H.toml
+++ b/flash/puya/P25Q16H.toml
@@ -1,0 +1,8 @@
+# Settings for the Puya P25Q16H 2MiB SPI flash.
+# Datasheet: https://datasheet.lcsc.com/lcsc/2006121819_-PUYA--P25Q16H-UXH-IR_C559220.pdf
+total_size = 0x200000 # 2 MiB # Page 17
+capacity = 0x15 
+manufacturer_id = 0x85 #  Page 49
+write_status_register_split = false
+01_continuous_status_write = true # page 21
+e7_quad_word_read = false # couldn't find in page 21/22

--- a/flash/puya/puya.toml
+++ b/flash/puya/puya.toml
@@ -1,0 +1,9 @@
+start_up_time_us = 5000
+manufacturer_id = 0x85  # Page 49 of https://datasheet.lcsc.com/lcsc/2006121819_-PUYA--P25Q16H-UXH-IR_C559220.pdf
+memory_type = 0x60      # Page 49 of https://datasheet.lcsc.com/lcsc/2006121819_-PUYA--P25Q16H-UXH-IR_C559220.pdf
+max_clock_speed_mhz = 104   # Page 10 of https://datasheet.lcsc.com/lcsc/2006121819_-PUYA--P25Q16H-UXH-IR_C559220.pdf
+quad_enable_bit_mask = 0x02 # page 24
+has_sector_protection = false
+quad_enable_status_byte = 2  # page 24
+6b_quad_read = true  # Page 21 of https://datasheet.lcsc.com/lcsc/2006121819_-PUYA--P25Q16H-UXH-IR_C559220.pdf
+32_qspi_write = true  # Page 21 of https://datasheet.lcsc.com/lcsc/2006121819_-PUYA--P25Q16H-UXH-IR_C559220.pdf

--- a/flash/puya/puya.toml
+++ b/flash/puya/puya.toml
@@ -1,3 +1,4 @@
+# This config is still untested.
 start_up_time_us = 5000
 manufacturer_id = 0x85  # Page 49 of https://datasheet.lcsc.com/lcsc/2006121819_-PUYA--P25Q16H-UXH-IR_C559220.pdf
 memory_type = 0x60      # Page 49 of https://datasheet.lcsc.com/lcsc/2006121819_-PUYA--P25Q16H-UXH-IR_C559220.pdf


### PR DESCRIPTION
@tannewt here is a first draft of config files for this new manufacturer and flash chip.

Lots of comments we need to clean up.  They are mostly for confirming with the datasheet found here:
https://datasheet.lcsc.com/lcsc/2006121819_-PUYA--P25Q16H-UXH-IR_C559220.pdf

This really need a review as I am not familiar with SPI flash and lots of the details are above my knowledge on the subject.
I tried to get as much information from the datasheet.  Based from the GD but updated with appropriate data.
I don't know if there are missing fields but since it's based from GD, I suspect this will be a good start...