### PR TITLE
Add Macronix MX25R3235F SPI flash

### DIFF
--- a/flash/macronix/MX25R3235F.toml
+++ b/flash/macronix/MX25R3235F.toml
@@ -1,0 +1,11 @@
+# Settings for the Macronix MX25R3235F 4MiB SPI flash.
+# Datasheet: https://www.macronix.com/Lists/Datasheet/Attachments/8385/MX25R3235F,%20Wide%20Range,%2032Mb,%20v1.0.pdf
+# By default its in lower power mode which can only do 8mhz. In high power mode it can do 80mhz.
+total_size = 0x400000 # 4 MiB
+start_up_time_us = 5000
+manufacturer_id = 0xc2
+memory_type = 0x28
+capacity = 0x16
+max_clock_speed_mhz = 8
+quad_enable_bit_mask = 0x40
+has_sector_protection = false


### PR DESCRIPTION
Settings for the Macronix MX25R3235F 32MiB SPI flash.

In the https://github.com/adafruit/circuitpython/pull/7833, @dhalbert asked if we could submit this to https://github.com/adafruit/nvm.toml, so it can be used by others. https://github.com/adafruit/circuitpython/pull/7833#discussion_r1158814639