### PR TITLE
Define quad enable status byte for W25Q16JVxM

### DIFF
--- a/flash/winbond/W25Q16JVxM.toml
+++ b/flash/winbond/W25Q16JVxM.toml
@@ -5,6 +5,7 @@ start_up_time_us = 5000
 memory_type = 0x70
 capacity = 0x15
 max_clock_speed_mhz = 133
+quad_enable_status_byte = 2
 quad_enable_bit_mask = 0x02
 write_status_register_split = false
 6b_quad_read = true


### PR DESCRIPTION
The chip does qspi, but didn't have the register defined, which causes compilation errors for the rp2040 port of circuitpython.