### PR TITLE
Add use_global_block_protection_lock to mram/everspin.

### DIFF
--- a/mram/everspin/everspin.toml
+++ b/mram/everspin/everspin.toml
@@ -10,3 +10,4 @@ write_status_register_split = false
 quad_enable_status_byte = 1
 6b_quad_read = false
 32_qspi_write = false
+use_global_block_protection_lock = false


### PR DESCRIPTION
Fixed missing `use_global_block_protection_lock = false` in `mram/everspin/everspin.toml` in #20.