### PR TITLE
Removed supports_fast_read variable from GD25Q80C.toml 

### DIFF
--- a/flash/gigadevice/GD25Q80C.toml
+++ b/flash/gigadevice/GD25Q80C.toml
@@ -5,6 +5,5 @@ capacity = 0x17
 write_status_register_split = false
 01_continuous_status_write = true
 e7_quad_word_read = true
-supports_fast_read = true
 start_up_time_us = 1800
 max_clock_speed_mhz = 120


### PR DESCRIPTION
The `supports_fast_read` variable is already set to `true` in the `flash/flash.toml` file and was failing to compile cirtcuitpython with the error `KeyAlreadyPresent: Key "supports_fast_read" already exists.`

Compiling without this variable inside `GD25Q80C` appears to work.